### PR TITLE
Resolve some NU1608 warnings in the RDPMonWebGUI.csproj

### DIFF
--- a/RDPMonWebGUI.csproj
+++ b/RDPMonWebGUI.csproj
@@ -67,6 +67,10 @@
     <PackageReference Include="NLog" Version="4.7.10" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.3" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.10.0" />
+	<PackageReference Include="Microsoft.CodeAnalysis" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi, I found some NU1608 warnings in the RDPMonWebGUI.csproj:

`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.CodeAnalysis.CSharp.Workspaces 3.4.0 requires Microsoft.CodeAnalysis.Common (= 3.4.0) but version Microsoft.CodeAnalysis.Common 3.10.0 was resolved.`
`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.CodeAnalysis.CSharp.Workspaces 3.4.0 requires Microsoft.CodeAnalysis.CSharp (= 3.4.0) but version Microsoft.CodeAnalysis.CSharp 3.10.0 was resolved.`
`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.CodeAnalysis.VisualBasic.Workspaces 3.4.0 requiresMicrosoft.CodeAnalysis.Common (= 3.4.0) but version Microsoft.CodeAnalysis.Common 3.10.0 was resolved.`
`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.CodeAnalysis.Workspaces.Common 3.4.0 requires Microsoft.CodeAnalysis.Common (= 3.4.0) but version Microsoft.CodeAnalysis.Common 3.10.0 was resolved.`
`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.CodeAnalysis.VisualBasic 3.4.0 requires Microsoft.CodeAnalysis.Common (= 3.4.0) but version Microsoft.CodeAnalysis.Common 3.10.0 was resolved.`

This fix can remove this warnings from RDPMonWebGUI's dependency graph.
Hope the PR can help you.

Best regards,
sucrose